### PR TITLE
Add GitHub action

### DIFF
--- a/.github/workflows/push-tokens.yml
+++ b/.github/workflows/push-tokens.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Git Checkout
         uses: actions/checkout@v2
-      - name: Pushes to another repository
+      - name: Push to gc-ds-core
         uses: cpina/github-action-push-to-another-repository@6e36e20d0ef541a7739b19a03280b844b26882e5
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
@@ -22,5 +22,16 @@ jobs:
           target-directory: 'src/variables/'
           destination-github-username: 'JoshBeveridge'
           destination-repository-name: 'gc-ds-core'
+          user-email: ${{ secrets.USER_EMAIL }}
+          target-branch: main
+      - name: Push to gc-ds-button
+        uses: cpina/github-action-push-to-another-repository@6e36e20d0ef541a7739b19a03280b844b26882e5
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source-directory: 'build/web/'
+          target-directory: 'src/styles/variables/'
+          destination-github-username: 'JoshBeveridge'
+          destination-repository-name: 'gc-ds-button'
           user-email: ${{ secrets.USER_EMAIL }}
           target-branch: main

--- a/.github/workflows/push-tokens.yml
+++ b/.github/workflows/push-tokens.yml
@@ -1,0 +1,26 @@
+name: Push Tokens
+on: 
+  push:
+    branches:
+      - main
+    paths:
+      - 'build/**'
+
+jobs:
+  deploy:
+    name: Push Tokens
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v2
+      - name: Pushes to another repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source-directory: 'build/web/'
+          target-directory: 'src/variables/'
+          destination-github-username: 'JoshBeveridge'
+          destination-repository-name: 'gc-ds-core'
+          user-email: ${{ secrets.USER_EMAIL }}
+          target-branch: main

--- a/.github/workflows/push-tokens.yml
+++ b/.github/workflows/push-tokens.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v2
       - name: Pushes to another repository
-        uses: cpina/github-action-push-to-another-repository@main
+        uses: cpina/github-action-push-to-another-repository@6e36e20d0ef541a7739b19a03280b844b26882e5
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:


### PR DESCRIPTION
# Summary | Résumé

GitHub action to automate pushing generated tokens in `/build/web/` directory to gc-ds-core for proof-of-concept.

Requires GitHub secrets :
- `API_TOKEN_GITHUB`: Personal access token
- `USER_EMAIL`: User email matching personal access token


# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

If pushed forward, which account details will be filled out in the repo's secrets.


